### PR TITLE
Aws infra

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+tab_width = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,38 @@ output_data/
 # IDEs and Editors
 .idea/
 .vscode/
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.37.0"
+  constraints = "3.37.0"
+  hashes = [
+    "h1:Tf6Os+utUxE8rEr/emCXLFEDdCb0Y6rsN4Ee84+aDCQ=",
+    "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf",
+    "zh:277dd05750187a41282cf6e066e882eac0dd0056e3211d125f94bf62c19c4b8b",
+    "zh:47050211f72dcbf3d99c82147abd2eefbb7238efb94d5188979f60de66c8a3df",
+    "zh:4a4e0d070399a050847545721dae925c192a2d6354802fdfbea73769077acca5",
+    "zh:4cbc46f79239c85d69389f9e91ca9a9ebf6a8a937cfada026c5a037fd09130fb",
+    "zh:6548dcb1ac4a388ed46034a5317fa74b3b0b0f68eec03393f2d4d09342683f95",
+    "zh:75b4a82596aa525d95b0b2847fe648368c6e2b054059c4dc4dcdee01d374b592",
+    "zh:75cf5cc674b61c82300667a82650f56722618b119ab0526b47b5ecbb4bbf49d0",
+    "zh:93c896682359039960c38eb5a4b29d1cc06422f228db0572b90330427e2a21ec",
+    "zh:c7256663aedbc9de121316b6d0623551386a476fc12b8eb77e88532ce15de354",
+    "zh:e995c32f49c23b5938200386e08b2a3fd69cf5102b5299366c0608bbeac68429",
+  ]
+}

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -19,3 +19,21 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:e995c32f49c23b5938200386e08b2a3fd69cf5102b5299366c0608bbeac68429",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/infra/dynamo_tables.tf
+++ b/infra/dynamo_tables.tf
@@ -1,0 +1,23 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table
+
+locals {
+  statelock_table_name = "${var.aws_dynamodb_table}-${random_integer.seed.result}"
+}
+
+resource "aws_dynamodb_table" "terraform_statelock" {
+    name = local.statelock_table_name
+    read_capacity = 20
+    write_capacity = 20
+    hash_key = "LockID"
+
+    attribute {
+      name = "LockID"
+      type = "S"
+    }
+
+    tags = var.default_tags
+}
+
+output "state_dynamo_table" {
+  value = aws_dynamodb_table.terraform_statelock.id
+}

--- a/infra/iam_group_memberships.tf
+++ b/infra/iam_group_memberships.tf
@@ -1,0 +1,13 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_membership
+
+resource "aws_iam_group_membership" "full_access" {
+  name  = "${local.bucket_name}-full-access"
+  users = var.full_access_users
+  group = aws_iam_group.bucket_full_access.name
+}
+
+resource "aws_iam_group_membership" "read_only" {
+  name  = "${local.bucket_name}-read-only"
+  users = var.read_only_users
+  group = aws_iam_group.bucket_read_only.name
+}

--- a/infra/iam_group_policies.tf
+++ b/infra/iam_group_policies.tf
@@ -1,0 +1,63 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy
+
+resource "aws_iam_group_policy" "full_access" {
+  name  = "${local.bucket_name}-full-access"
+  group = aws_iam_group.bucket_full_access.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": [
+                "arn:aws:s3:::${local.bucket_name}",
+                "arn:aws:s3:::${local.bucket_name}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["dynamodb:*"],
+            "Resource": [
+                "${aws_dynamodb_table.terraform_statelock.arn}"
+            ]
+        }
+    ]
+}
+EOF
+
+}
+
+resource "aws_iam_group_policy" "read_only" {
+  name  = "${local.bucket_name}-read_only"
+  group = aws_iam_group.bucket_full_access.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${local.bucket_name}",
+                "arn:aws:s3:::${local.bucket_name}/*"
+            ]
+        }
+    ]
+}
+EOF
+
+}
+
+output "s3_bucket" {
+  value = aws_s3_bucket.state_bucket.bucket
+}
+
+output "dynamodb_statelock" {
+  value = aws_s3_bucket.state_bucket.bucket
+}

--- a/infra/iam_groups.tf
+++ b/infra/iam_groups.tf
@@ -1,0 +1,14 @@
+#  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group
+
+resource "aws_iam_group" "bucket_full_access" {
+  name = "${local.bucket_name}-full-access"
+
+}
+
+resource "aws_iam_group" "bucket_read_only" {
+  name = "${local.bucket_name}-read-only"
+}
+
+# Notes:
+# We would probably want a `developers` group and
+# grant the correct privs to just that environment. A future activity.

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,14 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "3.37.0"
+    }
+  }
+}
+
+provider "aws" {
+    region = var.region
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,14 +1,18 @@
 # https://registry.terraform.io/providers/hashicorp/aws/latest
 
 terraform {
+  backend "s3" {
+    key = "networking/dev/terraform.tfstate"
+  }
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.37.0"
     }
   }
 }
 
 provider "aws" {
-    region = var.region
+  region = var.region
 }

--- a/infra/random_generator.tf
+++ b/infra/random_generator.tf
@@ -1,0 +1,6 @@
+
+# ensure some global uniqueness. Used for statefile and dynamodb statelock
+resource "random_integer" "seed" {
+  min = 1000
+  max = 9999
+}

--- a/infra/s3_buckets.tf
+++ b/infra/s3_buckets.tf
@@ -9,13 +9,22 @@ resource "aws_s3_bucket" "state_bucket" {
   bucket = local.bucket_name
   acl    = "private"
 
-  # as this is a demo, for sake of clean-up this is true
-  # - should make env aware so that it is always false on prod.
-  force_destroy = true
+  force_destroy = false
 
   versioning {
     enabled = true
   }
 
   tags = var.default_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_no_public_access" {
+  bucket              = aws_s3_bucket.state_bucket.id
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+
+output "state_bucket" {
+  value = aws_s3_bucket.state_bucket.id
 }

--- a/infra/s3_buckets.tf
+++ b/infra/s3_buckets.tf
@@ -18,6 +18,8 @@ resource "aws_s3_bucket" "state_bucket" {
   tags = var.default_tags
 }
 
+# TODO - did not work as expected - ideally block ability to make objects public.
+# can mitigate with iam set-up..
 resource "aws_s3_bucket_public_access_block" "s3_no_public_access" {
   bucket              = aws_s3_bucket.state_bucket.id
   block_public_acls   = true

--- a/infra/s3_buckets.tf
+++ b/infra/s3_buckets.tf
@@ -1,0 +1,21 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
+
+locals {
+  bucket_name = "${var.aws_bucket_prefix}-${random_integer.seed.result}"
+}
+
+# TODO: use KMS to encrypt bucket etc.
+resource "aws_s3_bucket" "state_bucket" {
+  bucket = local.bucket_name
+  acl    = "private"
+
+  # as this is a demo, for sake of clean-up this is true
+  # - should make env aware so that it is always false on prod.
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  tags = var.default_tags
+}

--- a/infra/s3_buckets.tf
+++ b/infra/s3_buckets.tf
@@ -6,9 +6,8 @@ locals {
 
 # TODO: use KMS to encrypt bucket etc.
 resource "aws_s3_bucket" "state_bucket" {
-  bucket = local.bucket_name
-  acl    = "private"
-
+  bucket        = local.bucket_name
+  acl           = "private"
   force_destroy = false
 
   versioning {
@@ -26,6 +25,23 @@ resource "aws_s3_bucket_public_access_block" "s3_no_public_access" {
   block_public_policy = true
 }
 
+# keeping simple for berevity for the tech-demo - however as per the tfstate
+# set-up, we can set more things here. See doclink above.
+# if this was a real set-up, we'd probably modularize all buckets to avoid
+# repetition and enforce standards.
+resource "aws_s3_bucket" "demo_data_bucket" {
+  bucket = "iw-demo-data"
+
+  acl           = "private"
+  force_destroy = false
+
+  versioning {
+    enabled = true
+  }
+
+  tags = var.default_tags
+
+}
 
 output "state_bucket" {
   value = aws_s3_bucket.state_bucket.id

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,22 @@
+# Best Practice - autotag resources
+variable "default_tags" {
+    type = map
+    default = {
+        key: "value",
+        Name: "Value",
+        managed_by_terraform: true,
+        department: "Data Engineering"
+  }
+}
+
+# Depending how you opt to provision resources, this can be very useful.
+# different aws accounts/zones or shared?
+variable "environment" {
+  type = string
+  default = "dev"
+}
+
+variable "region" {
+    type = "string"
+    default = "eu-west-1"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,3 +1,13 @@
+variable "aws_bucket_prefix" {
+  type = string
+  default = "infinityworks-demo"
+}
+
+variable "aws_dynamodb_table" {
+  type = string
+  default = "infinityworks-demo-tfstatelock"
+}
+
 # Best Practice - autotag resources
 variable "default_tags" {
     type = map
@@ -17,6 +27,6 @@ variable "environment" {
 }
 
 variable "region" {
-    type = "string"
+    type = string
     default = "eu-west-1"
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -26,6 +26,14 @@ variable "environment" {
   default = "dev"
 }
 
+variable "full_access_users" {
+  type = list(string)
+}
+
+variable "read_only_users" {
+  type = list(string)
+}
+
 variable "region" {
     type = string
     default = "eu-west-1"


### PR DESCRIPTION
In this branch, I have configured terraform on an s3 backend, including a `dynamodb_table` to act as the lock (good for teams with multiple developers).

I have also created an s3 bucket to hold the data for the next part of the tech-demo which is to create the snowflake data.

I also modelled some IAM related resources so that only certain users can modify the state. There is also a read-only access defined so that other users can still potentially read from tfstate if required for use in other areas.